### PR TITLE
remove errors on update with vim-plug

### DIFF
--- a/plugin/mru.vim
+++ b/plugin/mru.vim
@@ -21,7 +21,7 @@ function! mru#Open()
 	execute 'edit '.expand(p, ':')
 endfunction
 
-function s:List()
+function! s:List()
 	setlocal modifiable
 	let files = map(copy(g:MRU_FILE_LIST), 'fnamemodify(v:val, ":~:.")')
 	let n = len(files)
@@ -37,7 +37,7 @@ function s:List()
 	setlocal nomodifiable
 endfunction
 
-function s:Add()
+function! s:Add()
 	let cpath = expand('%:p')
 	if !filereadable(cpath)
 		return
@@ -54,7 +54,7 @@ function s:Add()
 	call insert(g:MRU_FILE_LIST, cpath)
 endfunction
 
-function s:ClearCurrentFile()
+function! s:ClearCurrentFile()
 	let cpath = expand('%:p')
 	call s:Remove(cpath)
 endfunction
@@ -68,7 +68,7 @@ function! mru#RemoveCurrentFile()
 	setlocal nomodifiable
 endfunction
 
-function s:Remove(path)
+function! s:Remove(path)
 	let idx = index(g:MRU_FILE_LIST, a:path)
 
 	if idx == -1


### PR DESCRIPTION
On ":PlugUpdate" using vim-plug, I get messages like these:

Error detected while processing /home/sridhar/code2/mru/plugin/mru.vim:
E122: Function <SNR>18_List already exists, add ! to replace it

This gets rid of those messages.